### PR TITLE
Improve topic classification and reporting

### DIFF
--- a/steam_agent/agent/verifiers.py
+++ b/steam_agent/agent/verifiers.py
@@ -17,4 +17,9 @@ def verify_dup_rate(dup_rate: float, max_dup: float = 0.05) -> bool:
     return dup_rate <= max_dup
 
 
-__all__ = ["verify_row_growth", "verify_dup_rate"]
+def verify_topic_density(blank_pct: float, max_blank: float = 0.50) -> bool:
+    """Return True when at least half the reviews receive a topic label."""
+    return blank_pct <= max_blank
+
+
+__all__ = ["verify_row_growth", "verify_dup_rate", "verify_topic_density"]

--- a/steam_agent/pipeline/classify.py
+++ b/steam_agent/pipeline/classify.py
@@ -2,42 +2,104 @@
 from __future__ import annotations
 
 import logging
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, Iterable, List, Sequence, Tuple
 
 import pandas as pd
 import yaml
 
 LOGGER = logging.getLogger(__name__)
 
-_POSITIVE = {
-    "good",
-    "great",
-    "love",
-    "fun",
-    "awesome",
-    "amazing",
+_TOPIC_PRIORITY: Tuple[str, ...] = (
+    "monetization",
+    "performance",
+    "combat",
+    "difficulty",
+    "progression",
+)
+
+_NEGATION_TERMS = {
+    "no",
+    "not",
+    "never",
+    "without",
+    "isnt",
+    "isn't",
+    "arent",
+    "aren't",
+    "dont",
+    "don't",
+    "doesnt",
+    "doesn't",
+    "didnt",
+    "didn't",
+    "cant",
+    "can't",
+    "won't",
+    "wont",
+    "shouldn't",
+    "shouldnt",
+    "couldn't",
+    "couldnt",
+}
+
+_POSITIVE_CUES: Tuple[str, ...] = (
+    "cheap",
+    "fair",
     "smooth",
+    "stable",
     "fast",
     "responsive",
+    "balanced",
+    "good",
+    "great",
+    "awesome",
+    "amazing",
+    "love",
+    "fun",
     "enjoy",
     "solid",
+)
+
+_NEGATIVE_TOPIC_CUES: Dict[str, Tuple[str, ...]] = {
+    "monetization": (
+        "expensive",
+        "overpriced",
+        "paywall",
+        "greedy",
+        "predatory",
+        "grindy",
+        "terrible",
+        "bad",
+    ),
+    "performance": ("crash", "stutter", "lag", "freeze", "fps drop"),
+    "difficulty": ("impossible", "unfair", "broken", "too hard", "cheap"),
+    "combat": ("clunky", "unresponsive", "delayed", "rollback"),
+    "progression": tuple(),
 }
-_NEGATIVE = {
-    "bad",
-    "terrible",
-    "hate",
-    "buggy",
-    "lag",
-    "slow",
-    "broken",
-    "crash",
-    "boring",
-    "grindy",
-    "paywall",
-    "expensive",
-    "stutter",
+
+_VARIANT_MAP: Dict[str, Tuple[str, ...]] = {
+    "price": ("price", "prices", "priced", "pricing"),
+    "microtransaction": ("microtransaction", "microtransactions"),
+    "dlc": ("dlc",),
+    "shop": ("shop", "shops", "store", "stores"),
+    "store": ("store", "stores", "shop", "shops"),
+    "currency": ("currency", "currencies"),
+    "coin": ("coin", "coins"),
+    "coins": ("coin", "coins"),
+    "battle pass": ("battle pass", "battle-pass", "battlepass"),
 }
+
+_WORD_RE = re.compile(r"\b\w+(?:'\w+)?\b")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+@dataclass(frozen=True)
+class _Pattern:
+    term: str
+    regex: re.Pattern[str]
 
 
 def _ensure_parent(path: Path) -> None:
@@ -51,40 +113,141 @@ def _load_taxonomy(path: Path) -> Dict[str, List[str]]:
     return {str(topic): [str(kw).lower() for kw in kws] for topic, kws in topics.items()}
 
 
-def _score_topic(text: str, keywords: List[str]) -> Dict[str, object] | None:
-    if not text:
-        return None
-    lowered = text.lower()
-    hits: List[str] = []
-    for kw in keywords:
-        if kw and kw in lowered:
-            hits.append(kw)
-    if not hits:
-        return None
+def _tokenize(text: str) -> List[str]:
+    return [token.strip("'") for token in _WORD_RE.findall(text.lower())]
 
-    tokens = lowered.split()
-    windows = max(1, len(tokens) // 20)
-    score = min(1.0, len(hits) / windows)
-    positive = any(token in _POSITIVE for token in tokens)
-    negative = any(token in _NEGATIVE for token in tokens)
-    if positive and not negative:
-        sentiment = 1
-    elif negative and not positive:
-        sentiment = -1
-    elif positive and negative:
-        sentiment = 0
-    else:
-        sentiment = 0
 
-    rationale = f"hits: {', '.join(sorted(set(hits)))}"
-    return {"confidence": score, "sentiment": sentiment, "rationale": rationale}
+def _phrase_variants(keyword: str) -> Iterable[str]:
+    base = keyword.lower().strip()
+    if not base:
+        return []
+    if base in _VARIANT_MAP:
+        return _VARIANT_MAP[base]
+
+    variants: set[str] = {base}
+    if " " not in base and base.isalpha():
+        if base.endswith("y") and len(base) > 2 and base[-2] not in "aeiou":
+            variants.add(f"{base[:-1]}ies")
+        elif base.endswith(("s", "x", "z", "ch", "sh")):
+            variants.add(f"{base}es")
+        else:
+            variants.add(f"{base}s")
+    return tuple(sorted(variants))
+
+
+def _compile_patterns(taxonomy: Dict[str, List[str]]) -> Dict[str, List[_Pattern]]:
+    compiled: Dict[str, List[_Pattern]] = {}
+    for topic, keywords in taxonomy.items():
+        topic_patterns: List[_Pattern] = []
+        seen: set[str] = set()
+        for keyword in keywords:
+            for variant in _phrase_variants(keyword):
+                if variant in seen:
+                    continue
+                seen.add(variant)
+                escaped = re.escape(variant)
+                pattern_text = escaped.replace(r"\ ", r"\s+")
+                regex = re.compile(rf"(?i)\b{pattern_text}\b")
+                topic_patterns.append(_Pattern(term=variant, regex=regex))
+        compiled[topic] = topic_patterns
+    return compiled
+
+
+def _sentence_hits(sentence: str, patterns: Sequence[_Pattern]) -> int:
+    hits = 0
+    for pattern in patterns:
+        hits += len(list(pattern.regex.finditer(sentence)))
+    return hits
+
+
+def _token_matches(token: str, cue_token: str) -> bool:
+    return token == cue_token or (token.startswith(cue_token) and len(token) > len(cue_token))
+
+
+def _phrase_occurrences(tokens: Sequence[str], phrase: str) -> List[int]:
+    cue_tokens = [tok for tok in phrase.split() if tok]
+    if not cue_tokens:
+        return []
+    window = len(cue_tokens)
+    hits: List[int] = []
+    for idx in range(len(tokens) - window + 1):
+        segment = tokens[idx : idx + window]
+        if all(_token_matches(seg, cue_tokens[pos]) for pos, seg in enumerate(segment)):
+            hits.append(idx)
+    return hits
+
+
+def _has_negation(tokens: Sequence[str], start: int, span: int) -> bool:
+    window_start = max(0, start - 3)
+    window_end = min(len(tokens), start + span + 3)
+    for idx in range(window_start, window_end):
+        if tokens[idx] in _NEGATION_TERMS:
+            return True
+    return False
+
+
+def _count_sentiment(tokens: Sequence[str], topic: str) -> Tuple[int, int, int]:
+    positive_hits = 0
+    negative_hits = 0
+    cue_matches = 0
+
+    negatives = _NEGATIVE_TOPIC_CUES.get(topic, tuple())
+    negative_set = set(negatives)
+
+    for cue in _POSITIVE_CUES:
+        if cue in negative_set:
+            continue
+        occurrences = _phrase_occurrences(tokens, cue)
+        for occ in occurrences:
+            cue_matches += 1
+            flipped = _has_negation(tokens, occ, len(cue.split()))
+            if flipped:
+                negative_hits += 1
+            else:
+                positive_hits += 1
+
+    bad_tokens = {"bad", "poor"}
+    for cue in negatives:
+        occurrences = _phrase_occurrences(tokens, cue)
+        if cue == "rollback" and occurrences:
+            # Require nearby negative qualifier
+            has_bad = any(
+                any(tokens[j] in bad_tokens for j in range(max(0, occ - 2), min(len(tokens), occ + 3)))
+                for occ in occurrences
+            )
+            if not has_bad:
+                continue
+        for occ in occurrences:
+            cue_matches += 1
+            flipped = _has_negation(tokens, occ, len(cue.split()))
+            if flipped:
+                positive_hits += 1
+            else:
+                negative_hits += 1
+
+    return positive_hits, negative_hits, cue_matches
+
+
+def _sentence_confidence(topic_hits: int, cue_hits: int, tokens: Sequence[str]) -> float:
+    if not tokens:
+        return 0.0
+    length = len(tokens)
+    effective_length = max(3, length - 2)
+    clamp_len = max(5.0, min(float(effective_length), 60.0))
+    score = (topic_hits + cue_hits) / clamp_len
+    return max(0.0, min(1.0, score))
+
+
+def _split_sentences(text: str) -> List[str]:
+    parts = _SENTENCE_SPLIT_RE.split(text)
+    return [part.strip() for part in parts if part and part.strip()]
 
 
 def classify(
     in_parquet: str,
     out_parquet: str,
     taxonomy: str,
-    min_conf: float = 0.55,
+    min_conf: float = 0.45,
 ) -> Dict[str, object]:
     """Assign topics to reviews using keyword matching."""
     src = Path(in_parquet)
@@ -96,33 +259,69 @@ def classify(
         raise FileNotFoundError(taxonomy)
 
     taxonomy_map = _load_taxonomy(tax_path)
+    pattern_map = _compile_patterns(taxonomy_map)
+
     df = pd.read_parquet(src)
     rows_in = int(df.shape[0])
 
-    labels: List[Dict[str, object]] = []
-    reviews_with_labels = set()
+    sentence_records: List[Dict[str, object]] = []
 
     for _, row in df.iterrows():
-        text = row.get("clean_text", "")
-        for topic, keywords in taxonomy_map.items():
-            score = _score_topic(text, keywords)
-            if not score:
+        review_id = row.get("review_id")
+        text = row.get("clean_text", "") or ""
+        sentences = _split_sentences(str(text))
+        for sentence in sentences:
+            lower_sentence = sentence.lower()
+            topic_hits_map: Dict[str, int] = {}
+            for topic, patterns in pattern_map.items():
+                hits = _sentence_hits(lower_sentence, patterns)
+                if hits:
+                    topic_hits_map[topic] = hits
+            if not topic_hits_map:
                 continue
-            if score["confidence"] < min_conf:
+
+            selected_topic = None
+            for topic in _TOPIC_PRIORITY:
+                if topic in topic_hits_map:
+                    selected_topic = topic
+                    break
+            if selected_topic is None:
+                # If taxonomy contains additional topics outside priority order
+                selected_topic = next(iter(topic_hits_map.keys()))
+
+            topic_hits = topic_hits_map[selected_topic]
+            tokens = _tokenize(sentence)
+            pos_hits, neg_hits, cue_hits = _count_sentiment(tokens, selected_topic)
+            if pos_hits > neg_hits:
+                sentiment = 1
+            elif neg_hits > pos_hits:
+                sentiment = -1
+            else:
+                sentiment = 0
+
+            confidence = _sentence_confidence(topic_hits, cue_hits, tokens)
+            if confidence < min_conf:
                 continue
-            labels.append(
+
+            sentence_records.append(
                 {
-                    "review_id": row.get("review_id"),
-                    "topic": topic,
-                    "sentiment": score["sentiment"],
-                    "confidence": round(float(score["confidence"]), 4),
-                    "rationale": score["rationale"],
+                    "review_id": review_id,
+                    "topic": selected_topic,
+                    "sentiment": sentiment,
+                    "confidence": round(confidence, 4),
+                    "rationale": sentence.strip(),
                 }
             )
-            reviews_with_labels.add(row.get("review_id"))
 
-    if labels:
-        labeled_df = pd.DataFrame(labels)
+    aggregated: Dict[Tuple[object, str], Dict[str, object]] = {}
+    for record in sentence_records:
+        key = (record["review_id"], record["topic"])
+        existing = aggregated.get(key)
+        if existing is None or record["confidence"] > existing["confidence"]:
+            aggregated[key] = record
+
+    if aggregated:
+        labeled_df = pd.DataFrame(aggregated.values())
     else:
         labeled_df = pd.DataFrame(columns=["review_id", "topic", "sentiment", "confidence", "rationale"])
 
@@ -130,15 +329,16 @@ def classify(
     _ensure_parent(dest)
     labeled_df.to_parquet(dest, index=False)
 
-    rows_labeled = int(labeled_df.shape[0])
-    blank_pct = float(1 - (len(reviews_with_labels) / rows_in)) if rows_in else 0.0
-    avg_conf = float(labeled_df["confidence"].mean()) if rows_labeled else 0.0
+    labeled_reviews = set(labeled_df["review_id"].dropna().tolist()) if not labeled_df.empty else set()
+    rows_labeled = len(labeled_reviews)
+    blank_pct = 1 - (rows_labeled / rows_in) if rows_in else 0.0
+    avg_conf = float(labeled_df["confidence"].mean()) if not labeled_df.empty else 0.0
 
     metrics = {
         "rows_in": rows_in,
         "rows_labeled": rows_labeled,
-        "blank_pct": round(blank_pct, 4),
-        "avg_conf": round(avg_conf, 4),
+        "blank_pct": round(float(blank_pct), 4),
+        "avg_conf": round(float(avg_conf), 4),
         "min_conf": min_conf,
     }
     LOGGER.info("Classification complete: %s", metrics)


### PR DESCRIPTION
## Summary
- update the classifier to work at the sentence level with boundary-aware keyword variants, sentiment cues, and confidence aggregation before emitting per-review topics
- ensure the weekly report counts distinct labeled reviews, avoids duplicate quotes by topic, and surfaces higher-confidence examples for each sentiment
- add a verifier for topic density and retry classification with a lower confidence floor when blank rates are too high

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2da7aafa8832eacb6bac62f9fe91b