### PR TITLE
Make pipeline language aware for topic density adjustments

### DIFF
--- a/steam_agent/agent/verifiers.py
+++ b/steam_agent/agent/verifiers.py
@@ -17,9 +17,17 @@ def verify_dup_rate(dup_rate: float, max_dup: float = 0.05) -> bool:
     return dup_rate <= max_dup
 
 
-def verify_topic_density(blank_pct: float, max_blank: float = 0.50) -> bool:
-    """Return True when at least half the reviews receive a topic label."""
-    return blank_pct <= max_blank
+def verify_topic_density(
+    blank_pct: float,
+    lang_kept: float,
+    expected_label_rate_en: float = 0.70,
+    max_slack: float = 0.20,
+) -> bool:
+    """Validate topic coverage relative to the detected language mix."""
+
+    expected = lang_kept * expected_label_rate_en
+    actual = lang_kept * (1.0 - blank_pct)
+    return actual >= (expected - max_slack)
 
 
 __all__ = ["verify_row_growth", "verify_dup_rate", "verify_topic_density"]

--- a/steam_agent/cli.py
+++ b/steam_agent/cli.py
@@ -42,6 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--embed-model", type=str, default="none")
     run_parser.add_argument("--min-conf", type=float, default=0.55)
     run_parser.add_argument("--use-pg", action="store_true")
+    run_parser.add_argument("--langs", type=str, default="en", help="Comma-separated language codes")
 
     test_parser = subparsers.add_parser("test-slice", help="Run a small validation slice")
     test_parser.add_argument("--app-id", type=int, default=1364780)
@@ -52,6 +53,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _parse_run_args(args: argparse.Namespace) -> RunConfig:
+    langs = [code.strip().lower() for code in args.langs.split(",") if code.strip()]
+
     return RunConfig(
         app_id=args.app_id,
         since=args.since,
@@ -67,6 +70,7 @@ def _parse_run_args(args: argparse.Namespace) -> RunConfig:
         embed_model=args.embed_model,
         min_conf=args.min_conf,
         use_pg=args.use_pg,
+        langs=langs,
     )
 
 
@@ -94,6 +98,7 @@ def main(argv: list[str] | None = None) -> int:
             report=defaults["report"],
             taxonomy=str(Path(__file__).resolve().parent / "agent" / "taxonomy.yaml"),
             max_reviews=args.limit,
+            langs=["en"],
         )
 
     return run_pipeline(config)

--- a/steam_agent/pipeline/prepare.py
+++ b/steam_agent/pipeline/prepare.py
@@ -4,15 +4,37 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
+
 import pandas as pd
 
 LOGGER = logging.getLogger(__name__)
 
 _WHITESPACE_RE = re.compile(r"\s+")
 _MARKUP_RE = re.compile(r"<[^>]+>")
+
+_EN_STOPWORDS = {"the", "and", "is", "this", "that", "with", "for", "not", "you"}
+_ES_STOPWORDS = {"el", "la", "los", "las", "que", "con", "para", "sin", "es"}
+_ACCENTED_CHARS = "áéíóúñü"
+
+_LANG_HINTS: Dict[str, str] = {
+    "english": "en",
+    "spanish": "es",
+    "latam": "es",
+    "latamspanish": "es",
+    "german": "de",
+    "french": "fr",
+    "italian": "it",
+    "portuguese": "pt",
+    "brazilian": "pt",
+    "schinese": "zh",
+    "tchinese": "zh",
+    "japanese": "ja",
+    "koreana": "ko",
+}
 
 
 def _ensure_parent(path: Path) -> None:
@@ -43,7 +65,56 @@ def _checksum(clean_text: str, ts: datetime, app_id: int) -> str:
     return sha.hexdigest()
 
 
-def prepare(in_csv: str, out_parquet: str, lang: str = "english") -> Dict[str, object]:
+def _normalize_lang_code(value: str | float | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and pd.isna(value):
+        return ""
+    text = str(value).strip().lower()
+    if not text:
+        return ""
+    if text in _LANG_HINTS:
+        return _LANG_HINTS[text]
+    if "-" in text:
+        text = text.split("-", 1)[0]
+    if len(text) == 2:
+        return text
+    return text[:2]
+
+
+def infer_language(text: str, provided_lang: str | None = None) -> str:
+    """Infer a short language code using lightweight heuristics."""
+    normalized_hint = _normalize_lang_code(provided_lang)
+    if normalized_hint:
+        return normalized_hint
+
+    if not isinstance(text, str):
+        return "unknown"
+
+    lowered = text.lower()
+    words = re.findall(r"[a-záéíóúñü]+", lowered)
+    if not words:
+        return "unknown"
+
+    en_hits = sum(1 for word in words if word in _EN_STOPWORDS)
+    es_hits = sum(1 for word in words if word in _ES_STOPWORDS)
+
+    accent_chars = sum(1 for ch in lowered if ch in _ACCENTED_CHARS)
+    alpha_chars = sum(1 for ch in lowered if ch.isalpha()) or 1
+    accent_ratio = accent_chars / alpha_chars
+
+    if es_hits > en_hits or accent_ratio > 0.05:
+        return "es"
+    if en_hits >= es_hits:
+        return "en"
+    return "unknown"
+
+
+def prepare(
+    in_csv: str,
+    out_parquet: str,
+    langs: List[str] | None = ["en"],
+) -> Dict[str, object]:
     """Prepare raw review CSV into a canonical Parquet dataset."""
     src = Path(in_csv)
     if not src.exists():
@@ -53,11 +124,10 @@ def prepare(in_csv: str, out_parquet: str, lang: str = "english") -> Dict[str, o
     df = pd.read_csv(src)
     rows_in = int(df.shape[0])
 
-    kept = 0
+    lang_counts: Dict[str, int] = {}
     if rows_in == 0:
         cleaned = pd.DataFrame(
-            columns=
-            [
+            columns=[
                 "review_id",
                 "app_id",
                 "ts",
@@ -69,34 +139,68 @@ def prepare(in_csv: str, out_parquet: str, lang: str = "english") -> Dict[str, o
                 "embed_model",
             ]
         )
+        rows_out = 0
     else:
-        df["language"] = df["language"].fillna("").str.lower()
-        df["lang_match"] = df["language"] == lang.lower()
-        kept = int(df["lang_match"].sum())
+        review_texts = df.get("review", pd.Series([""] * rows_in))
+        lang_hints = df.get("language", pd.Series([None] * rows_in))
+        detected_langs: List[str] = []
+        for text, hint in zip(review_texts, lang_hints):
+            normalized_text = "" if (not isinstance(text, str) and pd.isna(text)) else str(text)
+            detected_langs.append(infer_language(normalized_text, hint))
+        df["lang"] = detected_langs
+        lang_counts = {key: int(value) for key, value in Counter(detected_langs).items()}
 
-        df["ts"] = df["timestamp_created"].apply(lambda x: _parse_timestamp(str(x)))
-        df["clean_text"] = df["review"].apply(_clean_text)
-        df["helpful"] = df["votes_helpful"].fillna(0).astype(int)
-        df["funny"] = df["votes_funny"].fillna(0).astype(int)
-        df["app_id"] = df["app_id"].fillna(0).astype(int)
+        whitelist: Optional[set[str]]
+        if langs is None:
+            whitelist = None
+        else:
+            whitelist = {code.lower() for code in langs if code}
+        if whitelist is not None:
+            lang_mask = df["lang"].isin(whitelist)
+        else:
+            lang_mask = pd.Series([True] * rows_in)
 
-        df["version_checksum"] = df.apply(
-            lambda row: _checksum(row["clean_text"], row["ts"], row["app_id"]),
-            axis=1,
-        )
-        cleaned = df.loc[df["lang_match"], [
-            "review_id",
-            "app_id",
-            "ts",
-            "language",
-            "clean_text",
-            "helpful",
-            "funny",
-            "version_checksum",
-        ]].rename(columns={"language": "lang"})
-        cleaned["embed_model"] = "none"
+        filtered = df.loc[lang_mask].copy()
+        rows_out = int(filtered.shape[0])
 
-    pct_kept = float(kept / rows_in) if rows_in else 0.0
+        if rows_out == 0:
+            cleaned = pd.DataFrame(
+                columns=[
+                    "review_id",
+                    "app_id",
+                    "ts",
+                    "lang",
+                    "clean_text",
+                    "helpful",
+                    "funny",
+                    "version_checksum",
+                    "embed_model",
+                ]
+            )
+        else:
+            filtered["ts"] = filtered["timestamp_created"].apply(lambda x: _parse_timestamp(str(x)))
+            filtered["clean_text"] = filtered["review"].apply(_clean_text)
+            filtered["helpful"] = filtered["votes_helpful"].fillna(0).astype(int)
+            filtered["funny"] = filtered["votes_funny"].fillna(0).astype(int)
+            filtered["app_id"] = filtered["app_id"].fillna(0).astype(int)
+
+            filtered["version_checksum"] = filtered.apply(
+                lambda row: _checksum(row["clean_text"], row["ts"], row["app_id"]),
+                axis=1,
+            )
+            cleaned = filtered[[
+                "review_id",
+                "app_id",
+                "ts",
+                "lang",
+                "clean_text",
+                "helpful",
+                "funny",
+                "version_checksum",
+            ]]
+            cleaned["embed_model"] = "none"
+
+    pct_kept = float(rows_out / rows_in) if rows_in else 0.0
 
     dest = Path(out_parquet)
     _ensure_parent(dest)
@@ -104,8 +208,9 @@ def prepare(in_csv: str, out_parquet: str, lang: str = "english") -> Dict[str, o
 
     metrics = {
         "rows_in": rows_in,
-        "rows_out": int(cleaned.shape[0]),
+        "rows_out": rows_out,
         "pct_lang_kept": round(pct_kept, 4),
+        "lang_counts": lang_counts,
     }
     LOGGER.info("Prepare complete: %s", metrics)
     return metrics


### PR DESCRIPTION
## Summary
- add language inference, filtering, and metrics to the prepare step so downstream stages know the language mix
- update the control loop and verifiers to use language-aware topic density checks and retry classification when needed
- expose a --langs option via the CLI and surface language/coverage details in the final report footer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2e61ed424832e94288b3f556918de